### PR TITLE
Remove incorrect system requirements

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,12 +19,6 @@ Download the latest versions for the `x86_64-unknown-linux-gnu` target [here](ht
 
 For other targets, you will need to build the binaries [from source](`TODO link`).
 
-
-#### System requirements
-
-* 64-bit Linux (easiest with a Debian-based distribution)
-* At least 4GB of RAM (>8GB recommended)
-
 ## Running a node
 
 Nodes hold a copy of the entire ledger and have the vital role of being a source of


### PR DESCRIPTION
Neither of the stated system requirements is true.

It’s possible to compile the node for more platforms, not only 64bit Linux and the node doesn’t need that much memory. From what we’re observing it’s more like 300MiB. Not worth mentioning that.