### PR TITLE
Fix path to /docs/

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,9 +15,9 @@ module.exports = {
         src: 'img/logo.svg',
       },
       links: [
-        {to: '/intro', label: 'Docs', position: 'left'},
+        {to: '/docs/intro', label: 'Docs', position: 'left'},
         {href: 'https://radicle.community', label: 'Community', position: 'left'},
-        {to: '/faq', label: 'FAQ', position: 'left'},
+        {to: '/docs/faq', label: 'FAQ', position: 'left'},
         {
           href: 'https://github.com/radicle-dev',
           label: 'GitHub',
@@ -33,11 +33,11 @@ module.exports = {
           items: [
             {
               label: 'Intro',
-              to: '/intro',
+              to: '/docs/intro',
             },
             {
               label: 'Getting started',
-              to: '/getting-started',
+              to: '/docs/getting-started',
             },
           ],
         },
@@ -76,7 +76,7 @@ module.exports = {
       '@docusaurus/preset-classic',
       {
         docs: {
-          routeBasePath: '', // Set to empty string
+          //routeBasePath: '', // Set to empty string to remove /doc/
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
             'https://github.com/radicle-dev/radicle-run/edit/master/website/',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,7 +4,7 @@ import {Redirect} from '@docusaurus/router';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 function Home() {
-  return <Redirect to={useBaseUrl('/intro')} />;
+  return <Redirect to={useBaseUrl('/docs/intro')} />;
 }
 
 export default Home;

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,2 +1,1 @@
 registry.radicle.xyz
-


### PR DESCRIPTION
Reopen version of https://github.com/radicle-dev/radicle-run/pull/25

Merging this since this is how it was working out of the box, giving us the /docs/ prefix we want. We might need to fine-tune it but it's a functional start.

