### PR TITLE
Update local account terminology to key-pair

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,39 +90,45 @@ Explore our CLI to find more queries you can run.
 
 ### Submitting a transaction
 
+To submit a transaction, you need an account on the block chain,
+required to pay for [transaction fees](/docs/submit-transactions#transaction-fees).
+An account is controlled by a cryptographic key pair, from which
+the SS58 address that identifies it is derived.
+Key pairs are managed by the `radicle-registry-cli` and stored on disk.
 
-1. Generate an account
+1. Generate a key pair
 
-    You need an account to author transactions.
-    An account is a randomly generated key pair identified by a name of your choice.
-    To generate an account, run:
-
-    ```bash
-    radicle-registry-cli account generate <account_name>
-    ```
-
-    This command will give you the SS58 address for your new account.
-    E.g. generating an account named 'neo':
+    You need a key pair to author transactions.
+    The key pairs are randomly generated and identified by a name of your choice.
+    To generate a new key pair, run:
 
     ```bash
-    radicle-registry-cli account generate neo
-    ✓ Account generated successfully
-    ℹ SS58 address: 5HWP48i9TuP2VrRZrNeb6QzYpdUSE9BvyaptEqqHrLfH8ZPd
+    radicle-registry-cli key-pair generate <name>
     ```
 
-    You can always obtain the addresses of all your accounts by running:
+    This command will give you the SS58 address for your new key pair.
+    E.g. generating a key pair named 'neo':
+
+    ```bash
+    radicle-registry-cli key-pair generate neo
+    ✓ Key pair generated successfully
+    ⓘ SS58 address: 5HWP48i9TuP2VrRZrNeb6QzYpdUSE9BvyaptEqqHrLfH8ZPd
+    ```
+
+    You can always obtain the account addresses for all your key pairs by running:
 
     ``` bash
-    radicle-registry-cli account list
+    radicle-registry-cli key-pair list
     ```
 
 2. Request RADs
 
-    To interact with the ledger, you first need to get some RAD into your account to have enough
-    funds to pay for transactions fees.
+    To submit transactions, you first need to get some RAD into your account
+    to pay for transactions fees.
 
     Get in touch with us at <a href="https://webchat.freenode.net/#radicle" target="_blank" rel="noopener noreferrer">irc://irc.freenode.net/#radicle</a>
-    to request some RAD for your account. Please, bring your SS58 account address along.
+    to request some RAD for your account. Please, bring your SS58
+    account address along.
 
 3. Check your balance
 
@@ -138,7 +144,7 @@ Explore our CLI to find more queries you can run.
     For instance, you can register yourself as a user in our ledger by running:
 
     ``` bash
-    radicle-registry-cli user register <handle> --author <account_name>
+    radicle-registry-cli user register <handle> --author <key_pair_name>
     ```
 
     ⚠ Running this command will submit the transaction with a default fee value.

--- a/docs/node.md
+++ b/docs/node.md
@@ -42,11 +42,8 @@ successfully mined blocks. You can run a mining node with the following command.
 radicle-registry-node --mine <address>
 ```
 
-`address` is the public SS58 address of the account that should receive the
-mining rewards. You can run `radic-registry-cli key-pair generate` to
-generate a key pair for a new account and print the account’s address.
-(See also [“Submitting a transaction”](/docs/getting-started#submitting-a-transaction))
-transaction”](/docs/getting-started#submitting-a-transaction))
+The `address` argument is the public SS58 address of the account that should receive the
+mining rewards. If you wish to use a dedicated account for mining, use `radic-registry-cli key-pair generate` to generate a new key pair, which will print the associated account’s ss58 address that you can now pass to the command above. Otherwise, run `radic-registry-cli key-pair list` to find the ss58 address of a key pair you already have.
 
 If your node successfully mined a block and imported it will log `Imported own
 block`:

--- a/docs/submit-transactions.md
+++ b/docs/submit-transactions.md
@@ -16,13 +16,13 @@ and behaviour of each one of them.
 
 ⓘ All the transactions provide the same [Command-Line Options](#command-line-options).
 
-- Transfer funds from the author's account to another account, which can be a local, org's, or user's account.
+- Transfer funds from the author's account to another account.
 
     ``` bash
     radicle-registry-cli account transfer --help
     ```
 
-Transfer funds from an org's account to another account, which can be a local, org's, or user's account.
+Transfer funds from an org's account to another account.
 
     ``` bash
     radicle-registry-cli org transfer --help
@@ -65,9 +65,9 @@ Transfer funds from an org's account to another account, which can be a local, o
 
 1. Register a user
 
-    This example registers a user named "neo" in the registry using a
-    locally generated account (that happens to also be) named "neo"
-    to sign the transactions, specifying `100` as the fee.
+    This example registers a user named "neo" in the registry using the
+    local key pair (that happens to also be) named "neo" to sign the
+    transactions, specifying `100` as the fee.
 
     ``` bash
     radicle-registry-cli user register neo --author neo --fee 100
@@ -88,7 +88,7 @@ Transfer funds from an org's account to another account, which can be a local, o
     ```
 
     ⓘ The recipient of a transfer can either be a SS58 address
-       or one of your local account names.
+       or the name of one of your local key pairs.
 
 3. Unregister an org
 
@@ -109,13 +109,13 @@ can either be specified as options at the end of a command or as environment var
 
     ⚠ Requires having [getting started submitting a transaction](getting-started#submitting-a-transaction).
 
-    Mandatory for all transactions. The author option lets you specify the local account that
-    is used to sign the transaction. You can use the `account` command group to generate
-    and list the local accounts that you can to use to sign transactions.
+    Mandatory for all transactions. The author option lets you specify the key pair that
+    is used to sign the transaction. You can use the `key-pair` command group to `generate`
+    and `list` the key pairs that you can to use to sign transactions.
 
     ```
-    --author <account_name>
-        The name of the local account to be used to sign transactions
+    --author <key_pair_name>
+        The name of the local key pair to be used to sign transactions.
         [env: RAD_AUTHOR=]
     ```
 


### PR DESCRIPTION
Counterpart of https://github.com/radicle-dev/radicle-registry/issues/414, companion of https://github.com/radicle-dev/radicle-registry/pull/415.

:warning: Should **NOT** be merged before https://github.com/radicle-dev/radicle-registry/pull/415 is released.